### PR TITLE
Hugo binary file download and setup

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,9 @@ machine:
 
 dependencies:
   pre:
-    - go get -v github.com/spf13/hugo
+    - wget https://github.com/spf13/hugo/releases/download/v0.13/hugo_0.13_linux_amd64.tar.gz
+    - tar xfvz ~/hugo_0.13_linux_amd64.tar.gz
+    - mv ~/hugo_0.13_linux_amd64/hugo_0.13_linux_amd64 ~/.go_workspace/bin/hugo
     - git config --global user.name "leckyyyyyyy"
     - git config --global user.email "leckyyyyyyy@users.noreply.github.com"
 

--- a/circle.yml
+++ b/circle.yml
@@ -3,9 +3,9 @@ machine:
 
 dependencies:
   pre:
-    - wget https://github.com/spf13/hugo/releases/download/v0.13/hugo_0.13_linux_amd64.tar.gz
-    - tar xfvz ~/hugo_0.13_linux_amd64.tar.gz
-    - mv ~/hugo_0.13_linux_amd64/hugo_0.13_linux_amd64 ~/.go_workspace/bin/hugo
+    - wget -O ./hugo_0.13_linux_amd64.tar.gz https://github.com/spf13/hugo/releases/download/v0.13/hugo_0.13_linux_amd64.tar.gz
+    - tar xfvz ./hugo_0.13_linux_amd64.tar.gz
+    - mv ./hugo_0.13_linux_amd64/hugo_0.13_linux_amd64 ~/.go_workspace/bin/hugo
     - git config --global user.name "leckyyyyyyy"
     - git config --global user.email "leckyyyyyyy@users.noreply.github.com"
 


### PR DESCRIPTION
resolve #7 Hugo のバージョン違いによる影響をなくすためにバイナリファイルをダウンロードして
`$PATH` の通っている Go の実行バイナリを配置する `~/.go_workspace/bin/` にバイナリファイルを
セットアップします。
