### PR TITLE
Add Page of "Android Product Flavor unavailable name"

### DIFF
--- a/content/post/2015/android-product-flavor-unavailable-name.md
+++ b/content/post/2015/android-product-flavor-unavailable-name.md
@@ -1,0 +1,9 @@
++++
+date = "2015-05-30T16:19:48+09:00"
+slug = "android-product-flavor-unavailable-name"
+title = "Android Product Flavor で利用できない名前"
+
++++
+
+Product Flavor の名前に debug は利用できない。  
+`ProductFlavor names cannot collide with BuildType names` のエラーが出る。

--- a/content/post/2015/android-product-flavor-unavailable-name.md
+++ b/content/post/2015/android-product-flavor-unavailable-name.md
@@ -5,5 +5,8 @@ title = "Android Product Flavor で利用できない名前"
 
 +++
 
-Product Flavor の名前に debug は利用できない。  
+Product Flavor の名前に BuildType で定義している名前は利用できない。  
 `ProductFlavor names cannot collide with BuildType names` のエラーが出る。
+
+`release` はデフォルトで定義されているので気付いたけど、  
+`debug` を定義してみると同じエラーが出たので、予約されているようです。


### PR DESCRIPTION
Android Product Flavor で名前を設定しても Build Flavor と重複して利用できないとエラーが表示される。
