### PR TITLE
It wants to reduce the size of the link text of the index page

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,7 +3,7 @@
     <div>
     {{ range .Data.Pages }}
         <div>
-          <h3 class="entry-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
+          <h5 class="entry-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h5>
           <p>{{ .Date.Format "2006-01-02" }}</p>
         </div>
     {{ end }}


### PR DESCRIPTION
close #25 インデックスページのリンクテキストのサイズを h3 → h5 に変更する

![after](https://cloud.githubusercontent.com/assets/11652024/8144684/db11a32a-1224-11e5-887e-6dc6db823763.PNG)
