### PR TITLE
Setting permalink

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,6 +5,9 @@ contentdir = "content"
 layoutdir = "layouts"
 publishdir = "public"
 
+[permalinks]
+  post = "/post/:year/:slug/"
+
 [params]
   githubUrl = "https://github.com/leckyyyyyyy"
   twitterUrl = "https://twitter.com/leckyyyyyyy"


### PR DESCRIPTION
resolve #36 config.toml にパーマリンクの定義を設定する。

他のリポジトリで GitHub Pages を作成した場合 `[ユーザ名].github.io/[リポジトリ名]/` となるため、
パーマリンクに設定する内容もリポジトリ名に衝突しない文字のほうが良いと考えました。
デフォルトは `post/` でデフォルトのままでも衝突する可能性は低いと考えるので **post** とします。

ディレクトリの構成は、作成する記事の数/頻度から年単位でグルーピングできれば把握できる。
逆に月日の単位を含めると、細かすぎること + 月別のカテゴリーを利用するケースは低いと考えるので月日は含んでいません。

記事のタイトルをパーマリンクの定義に含めるとマルチバイト文字がエンコードされリンクが正しく扱えなくなるので、タイトルの代わりに `:slug` を利用して英数字(ハイフン含み)でリンクを表現させます。
